### PR TITLE
Create an issue template with a boilerplate header

### DIFF
--- a/.github/ISSUE_TEMPLATE/specification-issue.md
+++ b/.github/ISSUE_TEMPLATE/specification-issue.md
@@ -1,0 +1,12 @@
+---
+name: Specification Issue
+about: Create a new issue related to the OpenAPI Specification
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**PLEASE NOTE:** This project only maintains the written [OpenAPI Specification](../blob/master/versions/3.0.2.md) and a few other supporting artifacts. No OpenAPI-related tooling lives here. If your issue is with a documentation format, UI, editor, programming framework, or other [OpenAPI implementation](https://github.com/OAI/OpenAPI-Specification/blob/master/IMPLEMENTATIONS.md), please post your issue in the appropriate project repository or contact the provider.
+
+_Please delete the above notice before submitting._


### PR DESCRIPTION
This is a single issue template with a notice advising that the OpenAPI-Specification repo is only for issues related directly to the spec, not tooling.